### PR TITLE
Giving an option to add header to the rest request

### DIFF
--- a/src/CamundaRestRequest.php
+++ b/src/CamundaRestRequest.php
@@ -117,6 +117,9 @@ class CamundaRestRequest
     public function setJson(array $json): self
     {
         $this->setRequestOption(RequestOptions::JSON, $json);
+        if ($GLOBALS["headers"] !== null) {
+            $this->setRequestOption('headers',$GLOBALS["headers"]);
+        }
         return $this;
     }
 


### PR DESCRIPTION
Hi ,
I am new to PHP and new to Camunda. I admire your work, what you have done here. We have secured Camunda with firebase. So  i had to add headers to authenticate the Camunda Rest API. 

I tried my best to do it. Please check if there is a better elegant way to handle this. 